### PR TITLE
EM's changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,17 @@
-# Introduction 
+# Access trial software in Red Hat Marketplace 
 
-Introducing Red Hat® Marketplace, an open cloud marketplace that makes it easier to discover and access certified software for container-based environments in public clouds and on-prem. With automated deployment, software is immediately available to deploy on any Red Hat® OpenShift® cluster, providing a fast, integrated experience.
+For Red Hat® OpenShift® 4 users, [Red Hat® Marketplace](https://marketplace.redhat.com/en-us/about) gives you one place to access certified software for container-based environments. Software in the marketplace is immediately available to deploy on any Red Hat® OpenShift® cluster, providing a fast, integrated experience. In this tutorial, we show you how to install, set up and start using trial software in the marketplace, using the Findability Platform Predict Plus (FPPredict Plus) as an example. You can extend the instructions here for other software available on the Red Hat Marketplace.
 
-[Check this out to know more about Red Hat Marketplace](https://marketplace.redhat.com/en-us/about).
+### Quick intro to Findability Platform Predict Plus operator (Version - 0.0.4)
 
-### How to install, setup & get started using the Findability Platform Predict Plus operator on Red Hat OpenShift cluster
-
-In this tutorial, we demonstrate how to install, setup and get started using the Findability Platform Predict Plus (FPPredict Plus) operator from Red Hat Marketplace (RHM). Every operator on Red Hat Marketplace has different setup for installation and configuration and the focus of this tutorial is Findability Platform Predict Plus operator.
-
-The advantages of using RHM operators are per below.  
-
-* `Software for any cloud` :- Enterprise software for container-based environments in public clouds and on-prem
-
-* `Automated deployment` :- Fast, integrated experience with instant availability on Red Hat® OpenShift® clusters
-
-* `Fully supported` :- Free, continuous support for products purchased through Red Hat Marketplace
-
-### A brief about Findability Platform Predict Plus operator (Version - 0.0.4)
-
-FP-Predict +™, an Automated, self learning, and Multi Modeling Artificial Intelligence (AI) that handles Discrete Target variable, Continuous Target variable and Time series data with no need for coding. This operator will be helpful to solve some of the usecases under AI using different methods like Regression, Classification, Timeseries etc. This operator will be applicable to developers, data scientists, architects who wants to solve different usecases under machine learning and AI. 
-
+FP-Predict +™ is an automated, self learning, multi-modeling artificial intelligence (AI) tool that handles discrete target variables, continuous target variables, and time series data with no need for coding. <--EM: WHat is "no need for coding" referncing? Is it just a GUI that you can use?-->
 
 # Prerequisites
 
-* For all operators being installed from RHM, OpenShift cluster version 4.3 or higher is mandatory. Please set up Classic cluster using the instructions from below URL.
+* Red Hat OpenShift version 4.3 is requried to use with the software in Red Hat Markeplace. You can set up a class cluster using these instructions: 
+[Set up OpenShift Cluster](https://cloud.ibm.com/docs/openshift?topic=openshift-getting-started) <!--EM WHy are we sending them to our docs? This is just about how to use Red Hat OpenShift on IBM Cloud-->
 
-[Setting up OpenShift Cluster](https://cloud.ibm.com/docs/openshift?topic=openshift-getting-started)
-
-* We need to have an account created at Red Hat Marketplace by following this [link](https://marketplace.redhat.com/api-security/en-us/login/landing).
+* [Create an account](https://marketplace.redhat.com/api-security/en-us/login/landing)) on Red Hat Marketplace
 
 # Estimated time
 
@@ -35,135 +19,138 @@ It would take about an hour to complete the tutorial.
 
 # Steps
 
-### Access the RedHat OpenShift Container Platform (Web Console)
+## Access the RedHat OpenShift Container Platform web console
 
-Follow the steps below to launch the cluster console which is also called RedHat OpenShift Container Platform.
+Follow the steps below to launch the RedHat OpenShift Container Platform.
 
-Login to IBM Cloud Account and navigate to Dashboard
+1. Login to your IBM Cloud account and navigate to the dashboard:
 
-![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/dashboard.png)
+    ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/dashboard.png)
 
-Click on Clusters and select the cluster which you have created under prerequisites. In this tutorial, cluster name is `cp-rhm-poc`.
+1. Click **Clusters** and select the cluster you created in the prerequisites section. In this tutorial, the cluster name is `cp-rhm-poc`.
 
-![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/cluster.png)
+    ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/cluster.png)
 
-After you launch the cluster, click on `OpenShift web console` on the top right hand side.
+1. After you launch the cluster, click on **OpenShift web console** on the top right-hand side of the screen.
 
-![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/web-console.png)
+    ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/web-console.png)
 
-We can see the RedHat OpenShift Container Platform (Web Console). Click on question mark icon on the top right hand side and select `Command Line Tools`. 
+1. You should see the RedHat OpenShift Container Platform web console. Click the question mark icon on the top right-hand side and select **Command Line Tools**. 
 
-![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/cmd-line-tools.png)
+    ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/cmd-line-tools.png)
 
-Navigate to the section `oc - OpenShift Command Line Interface (CLI)` and download the respective oc binary onto your local system. This is needed to manage OpenShift projects from a terminal and is further extended to natively support OpenShift Container Platform features.
+1. Navigate to the section `oc - OpenShift Command Line Interface (CLI)` and download the respective oc binary onto your local system. You need this to manage OpenShift projects from a terminal. The binary is extended to natively support OpenShift Container Platform features.
 
-![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/oc-binary.png)
+    ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/oc-binary.png)
 
-We are all set to proceed to next step which is to register the OpenShift cluster on Red Hat Marketplace platform. This is mandatory to install any operators from RedHat Marketplace platform using the OpenShift cluster.
+Now you are ready to register the OpenShift cluster on Red Hat Marketplace. This step is mandatory to install any operators from Red Hat Marketplace platform using the OpenShift cluster.
 
-### Register the cluster on Red Hat Marketplace
+## Register the cluster on Red Hat Marketplace
 
-Sign up and login to RHM portal at [Link](https://marketplace.redhat.com/en-us) and click on workspace and then click on cluster. We need to add our new OpenShift cluster and register it on RHM platform.
+1. Log into the [Red Hat Marketplace](https://marketplace.redhat.com/en-us). Select a workspace and click **Cluster**. You need to add the new OpenShift cluster and register it on the Red Hat Marketplace platform.
 
-![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/add-cluster.png)
+    ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/add-cluster.png)
 
-Update the cluster name, generate the pull secret as per the instructions and save it. 
+1. Update the cluster name, generate the pull secret as per the instructions and save it. <!--EM: I'm confused about this. On the screen it looks like you create the secret, install the operator and then lick "Add cluster" but that's not what you're describing here is it?-->
 
-![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/cluster-details.png)
+    ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/cluster-details.png)
 
-Copy the curl command which starts with `curl -sL https` and append the pull secret towards the end. The entire script should be handy to be used in next step.
+1. Copy the curl command which starts with `curl -sL https` and append the pull secret towards the end. The entire script should be handy to be used in next step. <!--EM: Where is the reader getting a curl-command? Is that in the GUI? -->
 
-We need to start the cluster first to register it. Open a command prompt and type `oc login`, update the username and password which are used for accessing the cluster and hit enter. 
+1. You need to start the cluster first to register it. Open a command prompt and type `oc login`, update the username and password which are used for accessing the cluster, and press **Enter**. 
 
-![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/start-cluster.png)
+    ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/start-cluster.png)
 
-The cluster is up and running at this point. We need to run the entire script on command prompt which is copied from previous step and hit `enter` or `return` in Mac. It will take a couple of mins and we can see that we have successfully registered the cluster on RedHat Marketplace portal.
+Your cluster should be up and running at this point. You need to run the entire script on a command prompt which is copied from previous step and hit `enter` or `return` in Mac. It will take a couple of minutes to can see that you successfully registered the cluster on Red Hat Marketplace portal.
 
 ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/register-cluster.png)
 
-### Create a project in web console
+## Create a project in the web console <!--EM: Is this the RHM web console?-->
 
-We need to create a project to be used and managed from command line. Click on `Create Project` and give any name of your choice. We are using the name `findability-project` for this tutorial.
+Now we will show you how to create a project to be used and managed from command line. Click **Create Project** and name the project however you want. We use the name `findability-project` for this tutorial.
 
 ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/create-project.png)
 
-### Install the operator
+## Install the operator
 
-**Sign in to Red Hat Marketplace, navigate to the search bar and select `Findability Platform Predict Plus`.**
+1. Sign in to the Red Hat Marketplace, navigate to the search bar, and search for "Findability Platform Predict Plus".
 
-![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/sel-operator.png)
+    ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/sel-operator.png)
 
-**Choose the `Free trial` option in the next page and select the instance.**
+1. Choose the **Free trial** option on the next page and select the instance.<!--EM: The "instance" of what?-->
 
-![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/free-trial.png)
+    ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/free-trial.png)
 
-`Note` :- This is a trial instance with the following constraints per below.
+    > Note: This trial instance has the following constraints:
 
-* Up to 100K rows in training data and up to 50K rows in prediction data
-* Up to 500 variables, features and columns
-* 30 days free trial
+    * Up to 100K rows in training data and up to 50K rows in prediction data
+    * Up to 500 variables, features and columns
+    * 30 days free trial
 
-**Navigate to `Workspace` option at the top and click on `My software` option on the left pane.**
+1. Click the **Workspace** button at the top, followed by the **My software** option on the left pane.
 
-![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/software.png)
+    ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/software.png)
 
-**Choose the operator `FP-Predict+` by clicking on it and we will be directed to the next page where we need to choose `Install operator` from `Operators` menu.**
+1. Click the operator you want, in this case **FP-Predict+**. You will be directed to the next page where you need to choose **Install operator** from the Operators menu.
 
-![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/operator-install.png)
+    ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/operator-install.png)
 
-**Check the box under `Target clusters` and select the `Name` and choose the project name which was created in previous step under `Namespace Scope` option. We can leave the other default options as is and click `Install`. We are going ahead with Automatic method of installation, there is also an option do install the operator manually.**
+1. Under the Target clusters heading, check the box for the name of your cluster. Under "Namespace Scope", choose the project name you created in the previous step. You can leave the other default options and click **Install**. In this tutorial, we are choosing the automatic method of installation, but you can also choose to install the operator manually.
 
-![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/sel-namespace.png)
+    ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/sel-namespace.png)
 
-After a couple of minutes, the operator gets installed on the cluster. We should see the `Status` as `Up to date`. We can launch the web console by clicking on the option next to `Cluster Console`
+1. After a couple of minutes, the operator is installed on the cluster. The status should change to be "Up to date". Launch the web console by clicking on the option next to Cluster Console.
 
-![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/instld-optr.png)
+    ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/instld-optr.png)
 
-In the Web console, we can verify by clicking on Installed Operators under `Operators` option in the `left` navigation pane and see that the operator is successfully installed with status showing as Succeeded.
+1. In the web console, verify that you installed the operatory correctly by slecting **Operators** in the left navigation and by clicking on Installed Operators. The status should show that the installation succeeded.
 
-![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/installed-operator.png)
+   ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/installed-operator.png)
 
-### Create storage for the operator
+## Create storage for the operator
 
-We need to create persistent volume in the name of `fp-predict-plus-pv` to be bound to persistent volume claims. This step is necessary to enable storage capabilities for the operator to manage datasets. Click on persistent volume under Storage, update the name as `fp-predict-plus-pv` and storage capacity as 20 GB and hit `Create`. If we need more storage, we can increase it in the YAML file and create the persistent volume accordingly.
+1. Now that your operator is set up, you need to create persistent volume in the name of `fp-predict-plus-pv` to be bound to persistent volume claims. This step is necessary to enable storage capabilities for the operator to manage datasets. In the left navigation, Click **Storage > Persistent volume**. Update the name to `fp-predict-plus-pv` and set the storage capacity to 20 GB and hit **Create**. If you need more storage, you can increase it in the YAML file and create the persistent volume accordingly.
 
-![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/create-pv.png)
+    ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/create-pv.png)
 
-We need to create a persistent volume claim (storage) to use the storage created in previous step and bind it to the instance of this operator. Click on storage under Web Console and select Persistent Volume Claims.
+1. You need to create a persistent volume claim (storage) to use the storage created in the previous step and bind it to the instance of this operator. On the web console, click on **Storage** and select **Persistent Volume Claims**.
 
-![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/select-pvc.png)
+    ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/select-pvc.png)
 
-The next step is to create persistent volume claim. We can select Storage Class from Gold, Silver, Bronze which was created in previous step, give the name as `fp-predict-plus-pvc`, select single user access & assign the storage size as 20 GB. 
+1. The next step is to create a persistent volume claim. Choose the storage class you need &mdash; either gold, silver, or bronze. Add your name as `fp-predict-plus-pvc`, select single user access, and assign the storage size as 20 GB. 
 
-![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/create-pvc.png)
+    ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/create-pvc.png)
 
-After the persistent volume claim (PVC) is created, it needs to be bound with the persistent volume (PV) which was created in earlier step. We should see the status as `Bound` per below after couple of minutes.
+1. After you create the persistent volume claim (PVC), you need to bind it with the persistent volume (PV) which you created in tye earlier step. You should see the status as `Bound` per below after couple of minutes.
 
-![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/pvc-bound.png)
+    ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/pvc-bound.png)
 
-### Install the operand (Instance) of FPPredict Plus
+## Install the instance of FPPredict Plus
 
 Click on Installed operators under `Operators` and click on FP Predict Plus Operator to get the options like Overview, YAML, Subscription, Events, FP-Predict-Plus. Click on YAML and update the name per below under persistent volume with `useExisting as false`, name of persistent volume claims, routerCanonicalHostname would be the web console URL and hit `Save`. routerCanonicalHostname would start with the cluster name, cluster id till appdomain.cloud. The initial part in the URL - `https://console-openshift-console` should be removed while updating routerCanonicalHostname.
 
-![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/yaml-changes.png)
+![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/yaml-changes.png) <!--EM: Is this the wrong image? It doesnt' seem to go with teh text above-->
 
 The next step is to proceed towards FP-Predict-Plus option and click on Create FPpredictplus instance. Edit the YAML file and give a name for the instance and click `Save`.
 
 ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/operand.png)
 
-### Launch the operand (Instance) of FPPredict Plus
+### Launch the instance of FPPredict Plus
 
-We are all set to launch the instance. `How do we do it?` We need to click on Networking and select Routes and then click on the URL which is under the location to launch the instance. 
+Now you are set to launch the instance. To do so, click on Networking and select Routes and then click on the URL which is under the location to launch the instance. 
 
 ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/route.png)
+<!--EM: Is this the right image?-->
 
 ### Register the instance of FPPredict Plus
 
-We can login using the default credentials as per the [configuration file](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/credentials.txt), accept the end user license agreement and will be directed to the next page per below. Click on `Download` and share the file with the Findability Sciences support team. The support team will send the license file (with 30 days validity) and needs to be uploaded using the `Upload File` option. We are all set to access the instance of FPPredict Plus. 
+Log in using the default credentials as per the [configuration file](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/credentials.txt) and accept the end user license agreement. You will be directed to the next page as the following image shows. Click **Download** and share the file with the Findability Sciences support team. 
+
+The support team will send the license file (with 30 days validity) and needs to be uploaded using the `Upload File` option. We are all set to access the instance of FPPredict Plus. 
 
 ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/sys-info.png)
 
-After uploading the license key, we can bring up the `FP Predict+` instance per below. The navigation pane on the `left` has four options namely Dashboard, Analytics, Dataset Management & License Information. We are good to go from here. 
+After uploading the license key, bring up the `FP Predict+` instance like below. The navigation pane on the left should have four options:  Dashboard, Analytics, Dataset Management & License Information.
 
 ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/fp-predict.png)
 
@@ -171,7 +158,7 @@ After uploading the license key, we can bring up the `FP Predict+` instance per 
 
 # Summary
 
-With this, we have come to the end of this tutorial to understand all the aspects of installation, configuration, setup and more to get started using the FPPredict Plus operator from Red Hat Marketplace on OpenShift cluster to solve usecases under AI. Red Hat Marketplace is a one stop platform for exploring multiple operators which will help to solve some of the complex usecases under different domains. 
+This tutorial showed you how to install, configure, set up and add storage to get started using the FPPredict Plus operator from Red Hat Marketplace on OpenShift cluster to solve usecases under AI. Red Hat Marketplace is a one stop platform for exploring multiple operators which will help to solve some of the complex usecases under different domains. 
 
 # Related Links
 

--- a/README.md
+++ b/README.md
@@ -4,22 +4,22 @@ For Red Hat® OpenShift® 4 users, [Red Hat® Marketplace](https://marketplace.r
 
 ### Quick intro to Findability Platform Predict Plus operator (Version - 0.0.4)
 
-FP-Predict +™ is an automated, self learning, multi-modeling artificial intelligence (AI) tool that handles discrete target variables, continuous target variables, and time series data with no need for coding. <--EM: WHat is "no need for coding" referncing? Is it just a GUI that you can use?-->
+FP-Predict +™ is an automated, self learning, multi-modeling artificial intelligence (AI) tool that handles discrete target variables, continuous target variables, and time series data. Its GUI interface means no coding is required.
 
 # Prerequisites
 
-* Red Hat OpenShift version 4.3 is requried to use with the software in Red Hat Markeplace. You can set up a class cluster using these instructions: 
-[Set up OpenShift Cluster](https://cloud.ibm.com/docs/openshift?topic=openshift-getting-started) <!--EM WHy are we sending them to our docs? This is just about how to use Red Hat OpenShift on IBM Cloud-->
+* Red Hat OpenShift version 4.3 is requried to use with the software in Red Hat Markeplace. You can set up a class cluster on IBM Cloud using these instructions: 
+[Set up OpenShift Cluster](https://cloud.ibm.com/docs/openshift?topic=openshift-getting-started)
 
-* [Create an account](https://marketplace.redhat.com/api-security/en-us/login/landing)) on Red Hat Marketplace
+* [Create an account](https://marketplace.redhat.com/api-security/en-us/login/landing) on Red Hat Marketplace
 
 # Estimated time
 
-It would take about an hour to complete the tutorial.
+It will take about an hour to complete the tutorial.
 
 # Steps
 
-## Access the RedHat OpenShift Container Platform web console
+## Access the Red Hat OpenShift Container Platform web console
 
 Follow the steps below to launch the RedHat OpenShift Container Platform.
 
@@ -51,11 +51,11 @@ Now you are ready to register the OpenShift cluster on Red Hat Marketplace. This
 
     ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/add-cluster.png)
 
-1. Update the cluster name, generate the pull secret as per the instructions and save it. <!--EM: I'm confused about this. On the screen it looks like you create the secret, install the operator and then lick "Add cluster" but that's not what you're describing here is it?-->
+1. Update the cluster name, generate the pull secret as per the instructions and save it. <!--EM: I'm confused about this. On the screen it looks like you create the secret, install the operator and then click "Add cluster" but that's not what you're describing here is it?-->
 
     ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/cluster-details.png)
 
-1. Copy the curl command which starts with `curl -sL https` and append the pull secret towards the end. The entire script should be handy to be used in next step. <!--EM: Where is the reader getting a curl-command? Is that in the GUI? -->
+1. In the GUI, copy the curl command which starts with `curl -sL https` and append the pull secret towards the end. The entire script should be handy to be used in next step.
 
 1. You need to start the cluster first to register it. Open a command prompt and type `oc login`, update the username and password which are used for accessing the cluster, and press **Enter**. 
 
@@ -65,7 +65,7 @@ Your cluster should be up and running at this point. You need to run the entire 
 
 ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/register-cluster.png)
 
-## Create a project in the web console <!--EM: Is this the RHM web console?-->
+## Create a project in the Red Hat Marketplace web console
 
 Now we will show you how to create a project to be used and managed from command line. Click **Create Project** and name the project however you want. We use the name `findability-project` for this tutorial.
 
@@ -77,7 +77,7 @@ Now we will show you how to create a project to be used and managed from command
 
     ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/sel-operator.png)
 
-1. Choose the **Free trial** option on the next page and select the instance.<!--EM: The "instance" of what?-->
+1. Choose the **Free trial** option on the next page and select the software &mdash; in this case, Findability Platform Predict Plus.
 
     ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/free-trial.png)
 
@@ -103,7 +103,7 @@ Now we will show you how to create a project to be used and managed from command
 
     ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/instld-optr.png)
 
-1. In the web console, verify that you installed the operatory correctly by slecting **Operators** in the left navigation and by clicking on Installed Operators. The status should show that the installation succeeded.
+1. In the web console, verify that you installed the operatory correctly by selecting **Operators** in the left navigation and by clicking on Installed Operators. The status should show that the installation succeeded.
 
    ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/installed-operator.png)
 
@@ -117,30 +117,33 @@ Now we will show you how to create a project to be used and managed from command
 
     ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/select-pvc.png)
 
-1. The next step is to create a persistent volume claim. Choose the storage class you need &mdash; either gold, silver, or bronze. Add your name as `fp-predict-plus-pvc`, select single user access, and assign the storage size as 20 GB. 
+1. The next step is to create a persistent volume claim. Choose the storage class you need -- either gold, silver, or bronze. Add your name as `fp-predict-plus-pvc`, select single user access, and assign the storage size as 20 GB. 
 
     ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/create-pvc.png)
 
-1. After you create the persistent volume claim (PVC), you need to bind it with the persistent volume (PV) which you created in tye earlier step. You should see the status as `Bound` per below after couple of minutes.
+1. After you create the persistent volume claim (PVC), you need to bind it with the persistent volume (PV) which you created in the earlier step. You should see the status as `Bound` per below after couple of minutes.
 
     ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/pvc-bound.png)
 
 ## Install the instance of FPPredict Plus
 
-Click on Installed operators under `Operators` and click on FP Predict Plus Operator to get the options like Overview, YAML, Subscription, Events, FP-Predict-Plus. Click on YAML and update the name per below under persistent volume with `useExisting as false`, name of persistent volume claims, routerCanonicalHostname would be the web console URL and hit `Save`. routerCanonicalHostname would start with the cluster name, cluster id till appdomain.cloud. The initial part in the URL - `https://console-openshift-console` should be removed while updating routerCanonicalHostname.
+Follow these steps to install the instance, also known as the *operand*, of FPPredict Plus:
 
-![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/yaml-changes.png) <!--EM: Is this the wrong image? It doesnt' seem to go with teh text above-->
+1. Click on **Installed operators** under the Operators tab and select **FP Predict Plus Operator** to get the options like Overview, YAML, Subscription, Events, FP-Predict-Plus. 
 
-The next step is to proceed towards FP-Predict-Plus option and click on Create FPpredictplus instance. Edit the YAML file and give a name for the instance and click `Save`.
+    ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/operand.png)
 
-![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/operand.png)
+1. Select **YAML** and update the name per below under persistent volume with `useExisting as false`, name of persistent volume claims, routerCanonicalHostname would be the web console URL and hit `Save`. routerCanonicalHostname would start with the cluster name, cluster id till appdomain.cloud. The initial part in the URL - `https://console-openshift-console` should be removed while updating routerCanonicalHostname.
 
+    ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/yaml-changes.png)
+
+1. The next step is to proceed towards FP-Predict-Plus option and click on **Create FPpredictplus** instance. Edit the YAML file and give a name for the instance and click `Save`.
+    
 ### Launch the instance of FPPredict Plus
 
-Now you are set to launch the instance. To do so, click on Networking and select Routes and then click on the URL which is under the location to launch the instance. 
+Now you are set to launch the instance. To do so, click **Networking**, select **Routes**, and then click on the URL which is under the location to launch the instance. 
 
 ![](https://github.com/IBM/getting-started-with-fppredictplus/blob/master/images/route.png)
-<!--EM: Is this the right image?-->
 
 ### Register the instance of FPPredict Plus
 


### PR DESCRIPTION
I'm not sure if there's a misconception about this piece. I was told that this is how to get started using software in RHM and that FP+ is the example that others can follow. Is that not he case? I rewrote the introduction that way, so just let me know. 

Other changes:
Make it clear from the top that RHM is for RH OS 4 users
Lead with the problem: Getting started with the trial software isn’t easy

I’m very confused about the introduction of IBM Cloud in this piece. Do you have to have an IBM Cloud account to interact with RHM? If so, should that be in the prereqs. Or is this piece really about how to use IBM Cloud with RHM?  I’m afraid that the if this content is being written for people who use Red Hat OpenShift on IBM Cloud, then the audience might be too small. 

Now we are requiring readers to:
> Have an IBM Cloud account
> Have a Red Hat OpenSHift account
> Be using/migrated to OpenShift 4.3

